### PR TITLE
Fixed #1: "No type registered for ezdrawio" error

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -29,6 +29,11 @@ services:
         tags:
             - { name: ezpublish.fieldType.externalStorageHandler, alias: ezdrawio }
 
+    EzSystems\EzPlatformDrawIOFieldType\FieldType\DrawIO\SearchField:
+        public: true
+        tags:
+            - { name: ezpublish.fieldType.indexable, alias: ezdrawio }
+
     EzSystems\EzPlatformDrawIOFieldType\FieldType\DrawIO\Form\FormMapper:
         public: true
         tags:

--- a/src/lib/FieldType/DrawIO/SearchField.php
+++ b/src/lib/FieldType/DrawIO/SearchField.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace EzSystems\EzPlatformDrawIOFieldType\FieldType\DrawIO;
+
+use eZ\Publish\Core\FieldType\Image\SearchField as BaseSearchField;
+
+class SearchField extends BaseSearchField
+{
+
+}


### PR DESCRIPTION
Fixed issue #1 caused by missing `\eZ\Publish\SPI\FieldType\Indexable` implementation for `ezdrawio` field type.

// Review ping @SalvatorePollaci @kmadejski